### PR TITLE
feat(byoe): support Microsoft Store Slack native modules on Windows

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -25,10 +25,11 @@ $Protocol = 'slack'
 $ProgId = 'Slick.slack'
 $Shortcuts = @("$env:USERPROFILE\Desktop\Slick.lnk", "$env:APPDATA\Microsoft\Windows\Start Menu\Programs\Slick.lnk")
 
-function Register-SlackHandler($exe) {
+function Register-SlackHandler($exe, $iconFile) {
   $cmd = "`"$exe`" `"%1`""
+  $iconRes = if ($iconFile -and (Test-Path $iconFile)) { $iconFile } else { "$exe,0" }
   Reg "HKCU:\Software\Classes\$ProgId"                    @{ '(default)' = 'Slick'; 'FriendlyTypeName' = 'Slick'; 'URL Protocol' = '' }
-  Reg "HKCU:\Software\Classes\$ProgId\DefaultIcon"        @{ '(default)' = "$exe,0" }
+  Reg "HKCU:\Software\Classes\$ProgId\DefaultIcon"        @{ '(default)' = $iconRes }
   Reg "HKCU:\Software\Classes\$ProgId\shell\open\command" @{ '(default)' = $cmd }
   Reg "HKCU:\Software\Slick\Capabilities"                 @{ ApplicationName = 'Slick'; ApplicationDescription = 'Slack client mod (BYOE)' }
   Reg "HKCU:\Software\Slick\Capabilities\URLAssociations" @{ $Protocol = $ProgId }
@@ -55,7 +56,7 @@ function Get-PEArch($exe) {
   } catch { '' }
 }
 
-function Find-SlackResources {
+function Find-SlackStandalone {
   $base = Join-Path $env:LOCALAPPDATA 'slack'
   if (-not (Test-Path $base)) { return $null }
   Get-ChildItem $base -Directory -Filter 'app-*' -EA SilentlyContinue |
@@ -65,13 +66,43 @@ function Find-SlackResources {
     Select-Object -First 1
 }
 
+function Find-SlackMsix {
+  $base = 'HKLM:\SOFTWARE\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\PackageRepository\Packages'
+  try {
+    $pkgs = Get-ChildItem $base -EA Stop | Where-Object { $_.PSChildName -match '^com\.tinyspeck\.slackdesktop_' }
+    $pkgs = $pkgs | Sort-Object { try { [version](($_.PSChildName -split '_')[1]) } catch { [version]'0.0.0' } } -Descending
+    foreach ($pkg in $pkgs) {
+      try {
+        $installPath = (Get-ItemProperty $pkg.PSPath -Name Path -EA Stop).Path
+        $res = Join-Path $installPath 'app\resources'
+        if (Test-Path (Join-Path $res 'app.asar')) { return $res }
+      } catch {}
+    }
+  } catch {}
+  return $null
+}
+
+function Find-SlackResources {
+  $standalone = Find-SlackStandalone
+  $msix = Find-SlackMsix
+  $cands = @($standalone, $msix) | Where-Object { $_ }
+  if (-not $cands) { return $null }
+  $want = if ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64') { 'arm64' } else { 'x64' }
+  foreach ($res in $cands) {
+    $exe = Get-ChildItem (Split-Path $res) -Filter 'slack.exe' -EA SilentlyContinue | Select-Object -First 1
+    if ($exe -and (Get-PEArch $exe.FullName) -eq $want) { return $res }
+  }
+  return $cands | Select-Object -First 1
+}
+
 function Slack-Exe($res) { if ($res) { Get-ChildItem (Split-Path $res) -Filter 'slack.exe' -EA SilentlyContinue | Select-Object -First 1 } }
 
-function New-Shortcuts($exe) {
+function New-Shortcuts($exe, $iconFile) {
   $ws = New-Object -ComObject WScript.Shell
   foreach ($lnk in $Shortcuts) {
     $sc = $ws.CreateShortcut($lnk)
     $sc.TargetPath = $exe; $sc.WorkingDirectory = (Split-Path $exe); $sc.Description = 'Slick (Slack mod)'
+    if ($iconFile -and (Test-Path $iconFile)) { $sc.IconLocation = "$iconFile,0" }
     $sc.Save()
   }
 }
@@ -119,14 +150,18 @@ if ($Uninstall) {
 
 Step "Checking prerequisites"
 $slackRes = Find-SlackResources
-if (-not $slackRes) { Die "Slack not found under %LOCALAPPDATA%\slack - install the standalone Slack from https://slack.com/download first!" }
+if (-not $slackRes) { Die "Slack not found. Install Slack from https://slack.com/download (standalone) or from the Microsoft Store, then rerun." }
 Write-Host "    Slack resources: $slackRes"
 
-$slackExe = Slack-Exe $slackRes
-if ($slackExe -and (Get-PEArch $slackExe.FullName) -eq 'arm64') {
-  Die "Slick doesn't support the ARM64 (aka Microsoft Store) Slack. Install the x64 Slack from https://slack.com/download instead (it runs okish on ARM via fancy emulation), then rerun. Otherwise Slick can't be used here."
+$slackExe  = Slack-Exe $slackRes
+$slackArch = if ($slackExe) { Get-PEArch $slackExe.FullName } else {
+  if ($slackRes -match '\\WindowsApps\\[^\\]+_arm64_') { 'arm64' }
+  elseif ($slackRes -match '\\WindowsApps\\[^\\]+_x64_') { 'x64' }
+  else { 'x64' }
 }
-if ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64') {
+if ($slackArch -eq 'arm64') {
+  Write-Host "    Microsoft Store (MSIX) ARM64 Slack detected." -ForegroundColor Cyan
+} elseif ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64') {
   Write-Host "    note: x64 Slack on an ARM64 PC runs emulated (a drop in performance is expected)." -ForegroundColor Yellow
 }
 
@@ -143,15 +178,16 @@ if ($FromSource) {
 
   $eVer = ((Get-Content (Join-Path $Root 'byoe\package.json') -Raw | ConvertFrom-Json).dependencies.electron -replace '[^\d.]', '')
   if (-not $eVer) { Die "could not get electron version from byoe/package.json" }
-  Write-Host "    BYOE Electron pin: $eVer (win32-x64)"
+  $electronArch = $slackArch
+  Write-Host "    BYOE Electron pin: $eVer (win32-$electronArch)"
 
-  $dist = Join-Path $env:LOCALAPPDATA "slick-byoe\electron-$eVer-win32-x64"
+  $dist = Join-Path $env:LOCALAPPDATA "slick-byoe\electron-$eVer-win32-$electronArch"
   if (Test-Path (Join-Path $dist 'electron.exe')) {
     Step "Found Electron $eVer in cache"
   } else {
-    Step "Downloading Electron $eVer (win32-x64, ~140MB)"
-    $zip = Join-Path $env:TEMP "electron-$eVer-win32-x64.zip"
-    Invoke-WebRequest "https://github.com/electron/electron/releases/download/v$eVer/electron-v$eVer-win32-x64.zip" -OutFile $zip -UseBasicParsing
+    Step "Downloading Electron $eVer (win32-$electronArch, ~140MB)"
+    $zip = Join-Path $env:TEMP "electron-$eVer-win32-$electronArch.zip"
+    Invoke-WebRequest "https://github.com/electron/electron/releases/download/v$eVer/electron-v$eVer-win32-$electronArch.zip" -OutFile $zip -UseBasicParsing
     New-Item -ItemType Directory -Force $dist | Out-Null
     Expand-Archive $zip -DestinationPath $dist -Force
     Remove-Item $zip -EA SilentlyContinue
@@ -219,11 +255,17 @@ if ($FromSource) {
 $exe = Join-Path $Target 'Slick.exe'
 if (-not (Test-Path $exe)) { Die "install incomplete: $exe is missing" }
 
+$iconFile = if ($FromSource) { Join-Path $Root 'assets\icon.ico' } else { $null }
+
+$muiCache = 'HKCU:\Software\Classes\Local Settings\Software\Microsoft\Windows\Shell\MuiCache'
+Remove-ItemProperty $muiCache -Name "$exe.FriendlyAppName" -EA SilentlyContinue
+Remove-ItemProperty $muiCache -Name "$exe.ApplicationCompany" -EA SilentlyContinue
+
 Step "Registering Slick as the slack:// handler"
-Register-SlackHandler $exe
+Register-SlackHandler $exe $iconFile
 
 Step "Creating shortcuts"
-New-Shortcuts $exe
+New-Shortcuts $exe $iconFile
 
 Step "Launching Slick"
 Start-Process $exe

--- a/scripts/byoe/build-handoff-app-win.js
+++ b/scripts/byoe/build-handoff-app-win.js
@@ -98,7 +98,7 @@ function seedSettings(profile) {
   }
 }
 
-function indexSource(opts, defaultTheme) {
+function indexSource(opts, defaultTheme, profile) {
   return `'use strict';
 
 const fs = require('fs');
@@ -107,7 +107,7 @@ const path = require('path');
 const { app, dialog, shell } = require('electron');
 
 const SLICK_ROOT = path.join(process.resourcesPath, 'slick');
-const PROFILE = process.env.SLICK_HANDOFF_PROFILE || path.join(app.getPath('appData'), 'Slick');
+const PROFILE = process.env.SLICK_HANDOFF_PROFILE || ${JSON.stringify(profile)};
 const DEFAULT_THEME = ${JSON.stringify(defaultTheme)};
 const SLICK_VERSION = ${JSON.stringify(opts.appVersion)};
 const SLICK_BUILD = parseInt(${JSON.stringify(opts.buildNumber)}, 10) || 0;
@@ -127,7 +127,7 @@ function cmpVersion(a, b) {
 
 // Resolve the official Slack's resources dir at runtime. Two distributions:
 //   - standalone Squirrel build -> %LOCALAPPDATA%\\slack\\app-<version>\\resources (x64)
-//   - Microsoft Store MSIX build -> %ProgramFiles%\\WindowsApps\\com.tinyspeck...\\app\\resources (arm64)
+//   - Microsoft Store MSIX build -> %ProgramFiles%\\WindowsApps\\com.tinyspeck...\\app\\resources
 // Both bump versions on update, so never hard-code a path.
 function findSlackStandalone() {
   const base = path.join(process.env.LOCALAPPDATA || '', 'slack');
@@ -204,6 +204,8 @@ function findSlackResources() {
 
 const SLACK_RESOURCES = process.env.SLICK_SLACK_RESOURCES || findSlackResources();
 const SLACK_ASAR = path.join(SLACK_RESOURCES, 'app.asar');
+const SLACK_UNPACKED = path.join(SLACK_RESOURCES, 'app.asar.unpacked');
+const SLACK_APP_DIR = path.dirname(SLACK_RESOURCES);
 
 // Slack's native (.node) modules depend on the VC++ runtime DLLs that ship next
 // to Slack's binaries (one dir up from resources). Running Slack's code under
@@ -211,9 +213,55 @@ const SLACK_ASAR = path.join(SLACK_RESOURCES, 'app.asar');
 // Store/MSIX build, whose DLLs live in the ACL-locked WindowsApps dir and whose
 // arm64 VC++ runtime isn't installed system-wide. Prepend Slack's app dir so
 // dlopen() can resolve them.
-try {
-  process.env.PATH = path.dirname(SLACK_RESOURCES) + path.delimiter + (process.env.PATH || '');
-} catch {}
+process.env.PATH = [SLACK_APP_DIR, process.env.PATH || ''].filter(Boolean).join(path.delimiter);
+
+function slackElectronVersion() {
+  try {
+    return fs.readFileSync(path.join(SLACK_APP_DIR, 'version'), 'utf8').trim();
+  } catch {
+    return '';
+  }
+}
+
+function nativeMirrorId() {
+  try {
+    const stat = fs.statSync(SLACK_ASAR);
+    return [stat.size, Math.trunc(stat.mtimeMs)].join('-');
+  } catch {
+    return 'unknown';
+  }
+}
+
+// Windows permits reading another MSIX package's app.asar but rejects loading
+// executable code from its WindowsApps directory with ERROR_ACCESS_DENIED.
+function installNativeModuleMirror() {
+  if (!fs.existsSync(SLACK_UNPACKED)) return;
+
+  const mirror = path.join(PROFILE, 'slick', 'native', nativeMirrorId(), 'app.asar.unpacked');
+  const ready = path.join(mirror, '.complete');
+  if (!fs.existsSync(ready)) {
+    const staging = mirror + '.tmp-' + process.pid;
+    fs.rmSync(staging, { recursive: true, force: true });
+    fs.mkdirSync(path.dirname(staging), { recursive: true });
+    fs.cpSync(SLACK_UNPACKED, staging, { recursive: true });
+    fs.writeFileSync(path.join(staging, '.complete'), '');
+    fs.rmSync(mirror, { recursive: true, force: true });
+    fs.renameSync(staging, mirror);
+  }
+
+  process.env.PATH = [SLACK_APP_DIR, mirror, process.env.PATH || ''].filter(Boolean).join(path.delimiter);
+
+  const namespacedUnpacked = path.toNamespacedPath(path.resolve(SLACK_UNPACKED));
+  const unpackedPrefix = namespacedUnpacked + path.sep;
+  const dlopen = process.dlopen;
+  process.dlopen = function slickDlopen(module, filename, flags) {
+    const resolved = path.toNamespacedPath(path.resolve(filename));
+    const mapped = resolved.toLowerCase().startsWith(unpackedPrefix.toLowerCase())
+      ? path.join(mirror, path.relative(namespacedUnpacked, resolved))
+      : filename;
+    return dlopen.call(this, module, mapped, flags);
+  };
+}
 
 function preflight() {
   if (!fs.existsSync(SLACK_ASAR)) {
@@ -226,8 +274,25 @@ function preflight() {
     });
     return false;
   }
-  // NOTE: Windows has no easy on-disk Electron-version marker for Slack, so the
-  // build-time electron pin is trusted instead of a runtime mismatch dialog.
+  const slackElectron = slackElectronVersion();
+  if (slackElectron && slackElectron !== process.versions.electron) {
+    const choice = dialog.showMessageBoxSync({
+      type: 'error',
+      title: 'Slick',
+      message: 'This Slick build no longer matches Slack',
+      detail:
+        'Slack ships Electron ' +
+        slackElectron +
+        ', but this Slick build bundles Electron ' +
+        process.versions.electron +
+        '. Download the latest Slick release.',
+      buttons: ['Open Releases Page', 'Launch Anyway', 'Quit'],
+      defaultId: 0,
+      cancelId: 2,
+    });
+    if (choice === 0) shell.openExternal(RELEASES_URL);
+    return choice === 1;
+  }
   return true;
 }
 
@@ -372,6 +437,7 @@ if (!preflight()) {
 
   const getAppPath = app.getAppPath.bind(app);
   app.getAppPath = () => (process.env.SLICK_HANDOFF_KEEP_WRAPPER_APP_PATH === '1' ? getAppPath() : SLACK_ASAR);
+  installNativeModuleMirror();
 
   require(path.join(SLICK_ROOT, 'scripts/byoe/login-handoff.js'));
   require(path.join(SLICK_ROOT, 'scripts/byoe/inject.js'));
@@ -415,7 +481,7 @@ function main() {
       name: 'package.json',
       contents: `${JSON.stringify({ name: 'slick', productName: 'Slick', version: opts.appVersion, main: 'index.js' }, null, 2)}\n`,
     },
-    { name: 'index.js', contents: indexSource(opts, defaultTheme) },
+    { name: 'index.js', contents: indexSource(opts, defaultTheme, profile) },
   ];
   fs.rmSync(path.join(res, 'app'), { recursive: true, force: true });
   for (const name of ['default_app.asar', 'app.asar']) packAsar(files, path.join(res, name));

--- a/scripts/byoe/build-handoff-app-win.js
+++ b/scripts/byoe/build-handoff-app-win.js
@@ -424,6 +424,7 @@ if (!preflight()) {
   app.exit(1);
 } else {
   app.setPath('userData', PROFILE);
+  app.setAppUserModelId('Slick');
   // Claim slack:// so browser login handoff opens Slick (writes HKCU on Windows).
   try {
     app.setAsDefaultProtocolClient('slack');


### PR DESCRIPTION
## Summary

Adds support for Slack installed from the Microsoft Store (MSIX) on Windows.

Slack's `app.asar` can be read from the protected WindowsApps folder, but native `.node` modules cannot run directly from there when using Slick's BYOE Electron. This can prevent Slack from starting.

This change:

* Detects Microsoft Store Slack installs
* Copies `app.asar.unpacked` to Slick's profile folder
* Loads native modules from the copied files
* Adds Slack's install folder to `PATH` for native dependencies
* Warns if Slack's Electron version doesn't match the bundled BYOE Electron
* Keeps Slack's normal `process.resourcesPath` and `app.getAppPath()` behavior

## Verification

Tested with Slack 4.50.140 from the Microsoft Store.

Verified:

* Native modules load correctly (`slack-desktop-utils`, `registry-js`, `windows-focus-assist`)
* Slack starts and reaches `MAIN_WINDOW_SHOWN`
* NoTrack and Snappy plugins work
* No native module startup errors
* Lint and validation checks pass

Related to #11 