### PR TITLE
fix(windows): use stable native module mirror cache key

### DIFF
--- a/scripts/byoe/build-handoff-app-win.js
+++ b/scripts/byoe/build-handoff-app-win.js
@@ -104,6 +104,7 @@ function indexSource(opts, defaultTheme, profile) {
 const fs = require('fs');
 const https = require('https');
 const path = require('path');
+const crypto = require('crypto');
 const { app, dialog, shell } = require('electron');
 
 const SLICK_ROOT = path.join(process.resourcesPath, 'slick');
@@ -224,12 +225,13 @@ function slackElectronVersion() {
 }
 
 function nativeMirrorId() {
-  try {
-    const stat = fs.statSync(SLACK_ASAR);
-    return [stat.size, Math.trunc(stat.mtimeMs)].join('-');
-  } catch {
-    return 'unknown';
-  }
+  const version = slackElectronVersion();
+  if (version) return version;
+
+  return (
+    'unknown-' +
+    crypto.createHash('sha256').update(SLACK_APP_DIR).digest('hex').slice(0, 12)
+  );
 }
 
 // Windows permits reading another MSIX package's app.asar but rejects loading


### PR DESCRIPTION
## Summary

Use a stable cache key for the Windows native module mirror.

Previously the mirror directory name was derived from `app.asar` file metadata. On Microsoft Store/MSIX installations this metadata was not stable, causing new mirror directories to be created across launches.

This change:

* Uses Slack's Electron version as the primary mirror identifier.
* Falls back to a hash of the Slack installation path when the version file cannot be read.
* Avoids cache collisions for fallback cases.
* Keeps native module mirrors stable across launches.

## Testing

* Rebuilt Slick with `build-handoff-app-win.js --force`.
* Removed existing native mirror cache.
* Launched Slick multiple times on a Microsoft Store Slack installation.
* Verified native modules load successfully.
* Verified `%APPDATA%\Slick\slick\native` remains stable and contains a single `42.4.0` mirror directory.
* `npm run lint`
* `npm run validate`
