### PR TITLE
docs(windows): document Microsoft store Slack support

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ If you want to debug or poke around at things, you can find more manual scripts 
 ## Windows (beta)
 
 > [!NOTE]
-> Windows support is new and somehow even more unstable and prone to jank than the Mac build. It only supports the **x64** standalone Slack from [slack.com/download](https://slack.com/download) (not the MS store version). On ARM PCs the x64 Slack runs via emulation magic and Slick works, but expect a big performance hit.
+> Windows support is new and somehow even more unstable and prone to jank than the Mac build. Both the standalone Slack download and the Microsoft Store version are supported. On ARM PCs the x64 Slack runs via emulation magic and Slick works, but expect a big performance hit.
 
 Install Slack first, then run this in PowerShell:
 

--- a/scripts/byoe/build-handoff-app-win.js
+++ b/scripts/byoe/build-handoff-app-win.js
@@ -271,7 +271,7 @@ function preflight() {
       type: 'error',
       title: 'Slick',
       message: 'Slack is not installed',
-      detail: 'Slick needs the official Slack desktop app (the standalone download from slack.com, installed under %LOCALAPPDATA%\\\\slack). Install it, then open Slick again.',
+      detail: 'Slick requires Slack desktop to be installed. Both the standalone download and Microsoft Store version are supported. Install Slack, then open Slick again.',
       buttons: ['Quit'],
     });
     return false;


### PR DESCRIPTION
## Summary

Updates Windows documentation and installation messaging to reflect current support for both standalone and Microsoft Store Slack installations.

### Changes

* Update README Windows section to mention Microsoft Store Slack support.
* Update the missing-Slack error dialog to avoid implying only the standalone installer is supported.

### Testing

* Verified Slick launches successfully with a Microsoft Store Slack installation.
* Verified the updated installation guidance matches current behavior.
