### PR TITLE
docs(windows): document Microsoft Store Slack support

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -150,7 +150,7 @@ if ($Uninstall) {
 
 Step "Checking prerequisites"
 $slackRes = Find-SlackResources
-if (-not $slackRes) { Die "Slack not found. Install Slack from https://slack.com/download (standalone) or from the Microsoft Store, then rerun." }
+if (-not $slackRes) { Die "Slack not found. Install Slack Desktop from https://slack.com/download or the Microsoft Store, then rerun." }
 Write-Host "    Slack resources: $slackRes"
 
 $slackExe  = Slack-Exe $slackRes


### PR DESCRIPTION
## Summary

Updates Windows messaging in `build-handoff-app-win` to reflect support for both Slack installation methods:

* Standalone desktop download
* Microsoft Store installation

## Changes

* Update Windows handoff error message in `build-handoff-app-win`
* Align README wording with actual supported installation methods
* Update install script messaging

## Verification

Tested with Microsoft Store Slack (`4.50.140`) on Windows; Slick detected and launched successfully.
