### PR TITLE
feat(windows): add ARM64 release support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [x64]
+        arch: [x64, arm64]
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6

--- a/install.ps1
+++ b/install.ps1
@@ -232,15 +232,24 @@ if ($FromSource) {
 } else {
   Step "Finding the latest Slick release"
   $asset = $null; $tag = $null
+  $releaseArch = if ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64') { 'arm64' } else { 'x64' }
+  
   try {
     $rel = Invoke-RestMethod "https://api.github.com/repos/$Repo/releases/latest" -Headers @{ 'User-Agent' = 'slick-install' }
     $tag = $rel.tag_name
-    $asset = $rel.assets | Where-Object { $_.name -match 'win32-x64\.zip$' } | Select-Object -First 1
-  } catch { Die "could not reach GitHub to find a release ($($_.Exception.Message))" }
-  if (-not $asset) { Die "the latest release ($tag) has no Windows (win32-x64) build yet. Clone the repo and run install.ps1 to build from source: git clone https://github.com/$Repo" }
-
-  Step "Downloading Slick $tag (win32-x64)"
-  $zip = Join-Path $env:TEMP "slick-$tag-win32-x64.zip"
+    $asset = $rel.assets |
+      Where-Object { $_.name -match "win32-$releaseArch\.zip$" } |
+      Select-Object -First 1
+  } catch {
+    Die "could not reach GitHub to find a release ($($_.Exception.Message))"
+  }
+  
+  if (-not $asset) {
+    Die "the latest release ($tag) has no Windows (win32-$releaseArch) build yet. Clone the repo and run install.ps1 to build from source: git clone https://github.com/$Repo"
+  }
+  
+  Step "Downloading Slick $tag (win32-$releaseArch)"
+  $zip = Join-Path $env:TEMP "slick-$tag-win32-$releaseArch.zip"
   Invoke-WebRequest $asset.browser_download_url -OutFile $zip -UseBasicParsing
   $stage = Join-Path $env:TEMP ("slick-stage-" + [Guid]::NewGuid().ToString('N'))
   Expand-Archive $zip -DestinationPath $stage -Force


### PR DESCRIPTION
## Summary

Adds Windows ARM64 release support by:

* Publishing ARM64 artifacts in the release workflow
* Updating the installer to download the correct release asset based on the host architecture

## Changes

* Add `arm64` to the Windows release matrix in `.github/workflows/release.yml`
* Detect ARM64 systems in `install.ps1`
* Download `win32-arm64.zip` on ARM64 devices and `win32-x64.zip` otherwise
* Update installer messages to reflect the selected architecture

Fixes #99 
