### PR TITLE
fix: clipboard-sanitized-write permission for image copy

### DIFF
--- a/scripts/byoe/inject.js
+++ b/scripts/byoe/inject.js
@@ -240,6 +240,7 @@ let blockedCount = 0;
 
 const HOSTS = ['slack.com', 'slack-edge.com', 'slackb.com'];
 const PERMS = new Set([
+  'clipboard-sanitized-write',
   'display-capture',
   'fullscreen',
   'media',


### PR DESCRIPTION
slack copies images with the async clipboard api, which chromium locks behind the `clipboard-sanitized-write` permission. our perms allowlist didn't have it, so our own permission handler was denying it. classic self-sabotage