### PR TITLE
feat: theme editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ Themes are defined in the `themes/` folder as JSON files exporting the following
 
 No theme is applied by default, but you can pick one from the Slick tab in Preferences. `themes/amoled.json` (true black) and `themes/ultraviolet.json` (violet) are working examples. More documentation pending.
 
+Prefer to write your own CSS instead? Slick also has a "Custom CSS" option at the top of the theme list.
+
 ## Plugins
 
 Please refer to [`plugins/README.md`](plugins/README.md) for the plugins documentation. I promise it is not boring.

--- a/scripts/byoe/inject.js
+++ b/scripts/byoe/inject.js
@@ -63,6 +63,7 @@ const ENABLED_FILE = path.join(SETTINGS_DIR, 'enabled-plugins.json');
 const DEFAULT_ENABLED_FILE = path.join(PLUGINS_DIR, 'enabled.json');
 const ACTIVE_THEME_FILE = path.join(SETTINGS_DIR, 'active-theme');
 const PLUGIN_SETTINGS_FILE = path.join(SETTINGS_DIR, 'plugin-settings.json');
+const CUSTOM_CSS_FILE = path.join(SETTINGS_DIR, 'custom.css');
 const catalog = buildCatalog({ pluginsDir: PLUGINS_DIR, themesDir: THEMES_DIR });
 const defaultEnabled = () => catalog.plugins.map((plugin) => plugin.dir);
 const readEnabled = () =>
@@ -71,8 +72,10 @@ const runtime = {
   enabled: readEnabled(),
   pluginSettings: settings.readPluginSettings(PLUGIN_SETTINGS_FILE),
   theme: process.env.SLICK_THEME || settings.readActiveTheme(ACTIVE_THEME_FILE) || '',
+  customCss: settings.readCustomCss(CUSTOM_CSS_FILE),
 };
-let THEME_FILE = runtime.theme ? path.join(THEMES_DIR, `${runtime.theme}.json`) : null;
+let THEME_FILE =
+  runtime.theme && runtime.theme !== settings.CUSTOM_THEME_ID ? path.join(THEMES_DIR, `${runtime.theme}.json`) : null;
 
 function themeCss() {
   const spec = buildSpec(THEME_FILE);
@@ -177,7 +180,8 @@ function pluginCss() {
 }
 
 function fullCss() {
-  return [theme.css, pluginCss()].filter(Boolean).join('\n');
+  const customActive = runtime.theme === settings.CUSTOM_THEME_ID;
+  return [theme.css, pluginCss(), customActive ? runtime.customCss : ''].filter(Boolean).join('\n');
 }
 
 const armedSessions = new WeakSet();
@@ -197,10 +201,12 @@ function armBlocking(sess) {
         defaultEnabledFile: DEFAULT_ENABLED_FILE,
         activeThemeFile: ACTIVE_THEME_FILE,
         pluginSettingsFile: PLUGIN_SETTINGS_FILE,
+        customCssFile: CUSTOM_CSS_FILE,
         app,
         onTheme: setTheme,
         onEnabled: setEnabled,
         onPluginSetting: (_dir, _key, _value, all) => setPluginSettings(all),
+        onCustomCss: setCustomCss,
         onFileSetting: () =>
           electron.dialog
             .showOpenDialog({
@@ -572,6 +578,7 @@ function runtimeManifest() {
     enabled: runtime.enabled,
     activeTheme: runtime.theme,
     pluginSettings: runtime.pluginSettings,
+    customCss: runtime.customCss,
   });
 }
 
@@ -737,8 +744,9 @@ watchTheme();
 function setTheme(name) {
   name = name || '';
   if (name === runtime.theme) return;
-  const file = name ? path.join(THEMES_DIR, `${name}.json`) : null;
-  if (file && !fs.existsSync(file)) {
+  const isCustom = name === settings.CUSTOM_THEME_ID;
+  const file = name && !isCustom ? path.join(THEMES_DIR, `${name}.json`) : null;
+  if (!isCustom && file && !fs.existsSync(file)) {
     console.error(`[slick-byoe] theme not found: ${name}`);
     return;
   }
@@ -763,6 +771,13 @@ function setPluginSettings(all) {
   applyAllLive({ refreshCss: true });
 }
 
+function setCustomCss(css) {
+  css = css || '';
+  if (css === runtime.customCss) return;
+  runtime.customCss = css;
+  applyAllLive({ refreshCss: true });
+}
+
 function watchRuntimeFile(file, read, update) {
   fs.watchFile(file, { interval: 300 }, (curr, prev) => {
     if (curr.mtimeMs === prev.mtimeMs) return;
@@ -772,6 +787,7 @@ function watchRuntimeFile(file, read, update) {
 
 watchRuntimeFile(ENABLED_FILE, readEnabled, setEnabled);
 watchRuntimeFile(ACTIVE_THEME_FILE, () => settings.readActiveTheme(ACTIVE_THEME_FILE) || '', setTheme);
+watchRuntimeFile(CUSTOM_CSS_FILE, () => settings.readCustomCss(CUSTOM_CSS_FILE), setCustomCss);
 watchRuntimeFile(PLUGIN_SETTINGS_FILE, () => settings.readPluginSettings(PLUGIN_SETTINGS_FILE), setPluginSettings);
 
 const blockedPatternCount =

--- a/scripts/byoe/settings-renderer.js
+++ b/scripts/byoe/settings-renderer.js
@@ -33,7 +33,7 @@
       '#slick-panel-overlay{position:fixed;z-index:1200;overflow-y:auto;box-sizing:border-box;padding:20px 28px}',
       '#slick-panel-overlay .slick-intro{margin:0 0 18px;opacity:.62;line-height:1.45}',
       '#slick-panel-overlay .slick-legend{margin:0 0 12px}',
-      '#slick-panel-overlay .slick-plugin{padding:14px 0;border-top:1px solid rgba(127,127,127,.16)}',
+      '#slick-panel-overlay .slick-plugin{padding:14px 0;border-top:1px solid rgba(127,127,127,.16);position:relative}',
       '#slick-panel-overlay .slick-plugin:last-of-type{border-bottom:1px solid rgba(127,127,127,.16)}',
       '#slick-panel-overlay .slick-plugin .c-label{margin:0}',
       '#slick-applybar{position:sticky;bottom:-20px;margin:20px -28px -20px;padding:14px 28px;display:flex;align-items:center;gap:14px;background:rgba(127,127,127,.10);border-top:1px solid rgba(127,127,127,.2);backdrop-filter:blur(8px)}',
@@ -59,8 +59,7 @@
       '#slick-config-modal .slick-cfg-file .slick-cfg-file-button{flex:none}',
       '#slick-config-modal .slick-config-note{margin:14px 0 0;opacity:.55;font-size:12px}',
       '#slick-config-modal .slick-restart-required{display:inline-block;margin-left:8px;padding:1px 6px;border-radius:999px;background:rgba(224,30,90,.14);color:#e01e5a;font-size:11px;font-weight:600}',
-      '#slick-panel-overlay .slick-customcss-label{display:flex !important;flex-direction:row !important;align-items:center;gap:12px}',
-      '#slick-panel-overlay .slick-customcss-text{flex:1;min-width:0}',
+      '#slick-panel-overlay .slick-customcss-edit{position:absolute;top:50%;right:0;transform:translateY(-50%)}',
       '#slick-panel-overlay .slick-editor-back{opacity:.7;padding:4px 0;font-size:13px}',
       '#slick-panel-overlay .slick-editor-back:hover{opacity:1}',
       '#slick-panel-overlay .slick-customcss-editor{width:100%;min-height:320px;box-sizing:border-box;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:12px;line-height:1.5;padding:10px 12px;border-radius:8px;border:1px solid rgba(127,127,127,.3);background:rgba(127,127,127,.06);color:inherit;resize:vertical;tab-size:2}',
@@ -75,7 +74,7 @@
       (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' })[c],
     );
 
-  function row(text, sub, control, attrs = '') {
+  function row(text, sub, control, attrs = '', extra = '') {
     sub = sub ? '<span class="c-label__subtext" data-qa-label-subtext="true">' + esc(sub) + '</span>' : '';
     return (
       '<div class="slick-plugin"' +
@@ -91,7 +90,9 @@
       '<span class="c-label__children" data-qa-label-children="true">' +
       control +
       '</span>' +
-      '</label></div>'
+      '</label>' +
+      extra +
+      '</div>'
     );
   }
 
@@ -257,26 +258,12 @@
     (t.active ? ' checked' : '') +
     '>';
 
-  const customCssRow = (t) => {
-    const sub = t.description
-      ? '<span class="c-label__subtext" data-qa-label-subtext="true">' + esc(t.description) + '</span>'
-      : '';
-    return (
-      '<div class="slick-plugin">' +
-      '<label class="c-label c-label--pointer slick-customcss-label" data-qa-label="true">' +
-      themeRadio(t) +
-      '<span class="c-label__text slick-customcss-text" data-qa-label-text="true">' +
-      esc(t.label) +
-      sub +
-      '</span>' +
-      '<button class="c-button c-button--outline c-button--small" type="button" data-open-customcss>Edit Custom CSS</button>' +
-      '</label></div>'
-    );
-  };
-
   const themeRow = (t) => {
-    if (t.file !== CUSTOM_THEME_ID) return row(esc(t.label), t.description, themeRadio(t));
-    return customCssRow(t);
+    const extra =
+      t.file === CUSTOM_THEME_ID
+        ? '<button class="c-button c-button--outline c-button--small slick-customcss-edit" type="button" data-open-customcss>Edit Custom CSS</button>'
+        : '';
+    return row(esc(t.label), t.description, themeRadio(t), '', extra);
   };
 
   const rows = (items, render, dir) =>

--- a/scripts/byoe/settings-renderer.js
+++ b/scripts/byoe/settings-renderer.js
@@ -59,7 +59,8 @@
       '#slick-config-modal .slick-cfg-file .slick-cfg-file-button{flex:none}',
       '#slick-config-modal .slick-config-note{margin:14px 0 0;opacity:.55;font-size:12px}',
       '#slick-config-modal .slick-restart-required{display:inline-block;margin-left:8px;padding:1px 6px;border-radius:999px;background:rgba(224,30,90,.14);color:#e01e5a;font-size:11px;font-weight:600}',
-      '#slick-panel-overlay .slick-customcss-row{display:flex;align-items:center;gap:12px}',
+      '#slick-panel-overlay .slick-customcss-label{display:flex !important;flex-direction:row !important;align-items:center;gap:12px}',
+      '#slick-panel-overlay .slick-customcss-text{flex:1;min-width:0}',
       '#slick-panel-overlay .slick-editor-back{opacity:.7;padding:4px 0;font-size:13px}',
       '#slick-panel-overlay .slick-editor-back:hover{opacity:1}',
       '#slick-panel-overlay .slick-customcss-editor{width:100%;min-height:320px;box-sizing:border-box;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:12px;line-height:1.5;padding:10px 12px;border-radius:8px;border:1px solid rgba(127,127,127,.3);background:rgba(127,127,127,.06);color:inherit;resize:vertical;tab-size:2}',
@@ -256,16 +257,26 @@
     (t.active ? ' checked' : '') +
     '>';
 
+  const customCssRow = (t) => {
+    const sub = t.description
+      ? '<span class="c-label__subtext" data-qa-label-subtext="true">' + esc(t.description) + '</span>'
+      : '';
+    return (
+      '<div class="slick-plugin">' +
+      '<label class="c-label c-label--pointer slick-customcss-label" data-qa-label="true">' +
+      themeRadio(t) +
+      '<span class="c-label__text slick-customcss-text" data-qa-label-text="true">' +
+      esc(t.label) +
+      sub +
+      '</span>' +
+      '<button class="c-button c-button--outline c-button--small" type="button" data-open-customcss>Edit Custom CSS</button>' +
+      '</label></div>'
+    );
+  };
+
   const themeRow = (t) => {
     if (t.file !== CUSTOM_THEME_ID) return row(esc(t.label), t.description, themeRadio(t));
-    return row(
-      esc(t.label),
-      t.description,
-      '<span class="slick-customcss-row">' +
-        '<button class="c-button c-button--outline c-button--small" type="button" data-open-customcss>Edit Custom CSS</button>' +
-        themeRadio(t) +
-        '</span>',
-    );
+    return customCssRow(t);
   };
 
   const rows = (items, render, dir) =>

--- a/scripts/byoe/settings-renderer.js
+++ b/scripts/byoe/settings-renderer.js
@@ -6,6 +6,7 @@
 
   const S = window.__slickSettings || { controlUrl: 'https://slick.control/', plugins: [], themes: [], theme: '' };
   const TAB_ID = 'slick';
+  const CUSTOM_THEME_ID = '__custom__';
   const SEL = {
     overlay: '.p-prefs_dialog',
     modal: '.p-prefs_dialog__modal',
@@ -58,6 +59,11 @@
       '#slick-config-modal .slick-cfg-file .slick-cfg-file-button{flex:none}',
       '#slick-config-modal .slick-config-note{margin:14px 0 0;opacity:.55;font-size:12px}',
       '#slick-config-modal .slick-restart-required{display:inline-block;margin-left:8px;padding:1px 6px;border-radius:999px;background:rgba(224,30,90,.14);color:#e01e5a;font-size:11px;font-weight:600}',
+      '#slick-panel-overlay .slick-customcss-row{display:flex;align-items:center;gap:12px}',
+      '#slick-panel-overlay .slick-editor-back{opacity:.7;padding:4px 0;font-size:13px}',
+      '#slick-panel-overlay .slick-editor-back:hover{opacity:1}',
+      '#slick-panel-overlay .slick-customcss-editor{width:100%;min-height:320px;box-sizing:border-box;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:12px;line-height:1.5;padding:10px 12px;border-radius:8px;border:1px solid rgba(127,127,127,.3);background:rgba(127,127,127,.06);color:inherit;resize:vertical;tab-size:2}',
+      '#slick-panel-overlay .slick-customcss-editor:focus{outline:2px solid rgba(29,155,209,.5);outline-offset:1px}',
     ].join('\n');
     document.head.appendChild(st);
   }
@@ -243,16 +249,24 @@
     });
   }
 
-  const themeRow = (t) =>
-    row(
+  const themeRadio = (t) =>
+    '<input class="c-input_radio" type="radio" name="slick-theme" value="' +
+    esc(t.file) +
+    '"' +
+    (t.active ? ' checked' : '') +
+    '>';
+
+  const themeRow = (t) => {
+    if (t.file !== CUSTOM_THEME_ID) return row(esc(t.label), t.description, themeRadio(t));
+    return row(
       esc(t.label),
       t.description,
-      '<input class="c-input_radio" type="radio" name="slick-theme" value="' +
-        esc(t.file) +
-        '"' +
-        (t.active ? ' checked' : '') +
-        '>',
+      '<span class="slick-customcss-row">' +
+        '<button class="c-button c-button--outline c-button--small" type="button" data-open-customcss>Edit Custom CSS</button>' +
+        themeRadio(t) +
+        '</span>',
     );
+  };
 
   const rows = (items, render, dir) =>
     items.length
@@ -266,6 +280,7 @@
     ov.id = 'slick-panel-overlay';
     ov.style.display = 'none';
     ov.innerHTML =
+      '<div id="slick-view-list">' +
       '<p class="slick-intro">Configure your Slick settings here.</p>' +
       '<div class="c-legend slick-legend">Theme</div>' +
       '<div id="slick-theme-list">' +
@@ -278,8 +293,51 @@
       '<div id="slick-applybar" class="hidden">' +
       '<span class="slick-msg">These changes take effect after restarting Slick.</span>' +
       '<button id="slick-restart" class="c-button c-button--primary c-button--medium" type="button">Apply &amp; Restart</button>' +
+      '</div>' +
+      '</div>' +
+      '<div id="slick-view-editor" style="display:none">' +
+      '<button class="c-button-unstyled slick-editor-back" type="button" data-editor-back>&larr; Back</button>' +
+      '<div class="c-legend slick-legend" style="margin-top:14px">Custom CSS</div>' +
+      '<p class="slick-intro">Edits apply live, no restart needed. Select &ldquo;Custom CSS&rdquo; in the theme list to activate it.</p>' +
+      '<textarea id="slick-customcss" class="slick-customcss-editor" spellcheck="false" placeholder="/* your css here */"></textarea>' +
       '</div>';
     document.body.appendChild(ov);
+
+    function showView(name) {
+      const list = ov.querySelector('#slick-view-list');
+      const editor = ov.querySelector('#slick-view-editor');
+      if (list) list.style.display = name === 'editor' ? 'none' : 'block';
+      if (editor) editor.style.display = name === 'editor' ? 'block' : 'none';
+      if (name === 'editor') {
+        const ta = ov.querySelector('#slick-customcss');
+        if (ta) ta.focus();
+      }
+    }
+    ov.__slickShowView = showView;
+
+    const editBtn = ov.querySelector('[data-open-customcss]');
+    if (editBtn)
+      editBtn.addEventListener('click', (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        showView('editor');
+      });
+    const backBtn = ov.querySelector('[data-editor-back]');
+    if (backBtn) backBtn.addEventListener('click', () => showView('list'));
+
+    const cssArea = ov.querySelector('#slick-customcss');
+    if (cssArea) {
+      cssArea.value = S.customCss || '';
+      let cssDebounce;
+      cssArea.addEventListener('input', () => {
+        clearTimeout(cssDebounce);
+        const value = cssArea.value;
+        cssDebounce = setTimeout(() => {
+          ctl({ op: 'customcss', value });
+          S.customCss = value;
+        }, 400);
+      });
+    }
 
     ov.querySelectorAll('input[name="slick-theme"]').forEach((input) => {
       input.addEventListener('change', (e) => {
@@ -391,7 +449,10 @@
     } else {
       closeConfig();
       const ov = $('slick-panel-overlay');
-      if (ov) ov.style.display = 'none';
+      if (ov) {
+        ov.style.display = 'none';
+        if (ov.__slickShowView) ov.__slickShowView('list');
+      }
       const tab = $(TAB_ID);
       if (tab) tab.classList.remove('c-tabs__tab--active');
     }

--- a/scripts/byoe/settings-ui.js
+++ b/scripts/byoe/settings-ui.js
@@ -7,6 +7,7 @@ const { allPluginSettings, mergeSettings, coerceSetting } = require('./plugins')
 const CONTROL_HOST = 'slick.control';
 const controlPattern = `*://${CONTROL_HOST}/*`;
 const controlUrl = `https://${CONTROL_HOST}/`;
+const CUSTOM_THEME_ID = '__custom__';
 const RENDERER_FILE = path.join(__dirname, 'settings-renderer.js');
 const RENDERER_SOURCE = fs.readFileSync(RENDERER_FILE, 'utf8');
 
@@ -55,11 +56,23 @@ function writeActiveTheme(file, name) {
   fs.writeFileSync(file, String(name).trim() + '\n');
 }
 
+function readCustomCss(file) {
+  try {
+    return fs.readFileSync(file, 'utf8');
+  } catch {
+    return '';
+  }
+}
+function writeCustomCss(file, css) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, String(css == null ? '' : css));
+}
+
 function listThemes(catalog, activeName) {
   return catalog.themes.map((theme) => ({ ...theme, active: theme.file === activeName }));
 }
 
-function buildManifest({ catalog, enabled, activeTheme, pluginSettings }) {
+function buildManifest({ catalog, enabled, activeTheme, pluginSettings, customCss }) {
   const plugins = catalog.plugins.map(({ dir, meta, schema }) => {
     return {
       dir,
@@ -71,17 +84,25 @@ function buildManifest({ catalog, enabled, activeTheme, pluginSettings }) {
     };
   });
   const themes = listThemes(catalog, activeTheme);
+  const customActive = activeTheme === CUSTOM_THEME_ID;
   themes.unshift({
     file: '',
     label: 'Default',
     description: 'Stock Slack appearance (no theme)',
-    active: !themes.some((t) => t.active),
+    active: !customActive && !themes.some((t) => t.active),
+  });
+  themes.unshift({
+    file: CUSTOM_THEME_ID,
+    label: 'Custom CSS',
+    description: 'Your own live-edited CSS',
+    active: customActive,
   });
   return {
     controlUrl,
     theme: activeTheme || '',
     themes,
     plugins,
+    customCss: customCss || '',
   };
 }
 
@@ -106,11 +127,13 @@ function handleControl(
     defaultEnabledFile,
     activeThemeFile,
     pluginSettingsFile,
+    customCssFile,
     app,
     onTheme,
     onEnabled,
     onPluginSetting,
     onFileSetting,
+    onCustomCss,
   },
 ) {
   let u;
@@ -133,7 +156,10 @@ function handleControl(
     }
   } else if (op === 'theme') {
     const name = u.searchParams.get('name');
-    if (name !== null && (name === '' || catalog.themes.some((theme) => theme.file === name))) {
+    if (
+      name !== null &&
+      (name === '' || name === CUSTOM_THEME_ID || catalog.themes.some((theme) => theme.file === name))
+    ) {
       writeActiveTheme(activeThemeFile, name);
       console.log(`[slick-settings] theme -> ${name || 'none'}`);
       if (onTheme) {
@@ -177,6 +203,19 @@ function handleControl(
           if (onPluginSetting) onPluginSetting(dir, key, value, all);
         })
         .catch((e) => console.error('[slick-settings] file picker failed:', e.message));
+  } else if (op === 'customcss') {
+    const css = u.searchParams.get('value');
+    if (css !== null && customCssFile) {
+      writeCustomCss(customCssFile, css);
+      console.log(`[slick-settings] custom css -> ${css.length} byte(s)`);
+      if (onCustomCss) {
+        try {
+          onCustomCss(css);
+        } catch (e) {
+          console.error('[slick-settings] onCustomCss failed:', e.message);
+        }
+      }
+    }
   } else if (op === 'restart') {
     console.log('[slick-settings] relaunching to apply plugin changes');
     if (app) {
@@ -191,6 +230,7 @@ module.exports = {
   CONTROL_HOST,
   controlPattern,
   controlUrl,
+  CUSTOM_THEME_ID,
   buildManifest,
   bootstrapScript,
   handleControl,
@@ -202,4 +242,6 @@ module.exports = {
   listThemes,
   readActiveTheme,
   writeActiveTheme,
+  readCustomCss,
+  writeCustomCss,
 };


### PR DESCRIPTION
Introducing custom CSS, because apparently I looked at vencords's quick CSS and said "we want that too" (we're already contractually obligated to steal from them):

- custom CSS slot in themes
- in-app editor with hot reload

cool stuff:

<img width="933" height="661" alt="image" src="https://github.com/user-attachments/assets/d1d69d1e-b8d4-428e-84a4-b986905feb3a" />
<img width="701" height="628" alt="image" src="https://github.com/user-attachments/assets/ce21308b-8cc3-4ec9-be98-4b05a0a654ab" />
