### PR TITLE
feat: artifact attestations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,12 +4,13 @@ on:
   push:
     tags: ['v*']
 
-permissions:
-  contents: write
-
 jobs:
   build-mac:
     runs-on: macos-26
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     strategy:
       fail-fast: false
       matrix:
@@ -53,6 +54,12 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
         run: node scripts/release/build-release-mac.js --build-number "${{ steps.version.outputs.build }}" --arch "${{ matrix.arch }}"
+      - name: Attest build provenance
+        uses: actions/attest@v4
+        with:
+          subject-path: |
+            dist/Slick-*.zip
+            dist/Slick-*.dmg
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
         with:
@@ -65,6 +72,10 @@ jobs:
 
   build-win:
     runs-on: windows-latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     strategy:
       fail-fast: false
       matrix:
@@ -85,6 +96,10 @@ jobs:
           echo "build=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
       - name: Build release artifact
         run: node scripts/release/build-release-win.js --build-number "${{ steps.version.outputs.build }}" --arch "${{ matrix.arch }}"
+      - name: Attest build provenance
+        uses: actions/attest@v4
+        with:
+          subject-path: dist/Slick-*-win32-*.zip
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
         with:
@@ -95,6 +110,10 @@ jobs:
 
   build-linux:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
     strategy:
       fail-fast: false
       matrix:
@@ -115,6 +134,10 @@ jobs:
           echo "build=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
       - name: Build release artifact
         run: node scripts/release/build-release-linux.js --build-number "${{ steps.version.outputs.build }}" --arch "${{ matrix.arch }}"
+      - name: Attest build provenance
+        uses: actions/attest@v4
+        with:
+          subject-path: dist/Slick-*-linux-*.tar.gz
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
         with:
@@ -126,6 +149,8 @@ jobs:
   release:
     needs: [build-mac, build-win, build-linux]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Read build number
         id: version

--- a/README.md
+++ b/README.md
@@ -102,6 +102,19 @@ git tag "v$BUILD"
 git push origin "v$BUILD"
 ```
 
+## Verifying builds
+
+All builds published from this repo include [GitHub artifact attestations](https://docs.github.com/en/actions/concepts/security/artifact-attestations) (SLSA build provenance). These prove a given zip, dmg, or tarball was built by this repository's release workflow, not swapped in after the fact.
+
+With the [GitHub CLI](https://cli.github.com/) installed, run:
+
+```bash
+gh attestation verify path/to/Slick-build-N-….zip -R 3kh0/slick
+# same idea for .dmg or .tar.gz
+```
+
+A successful check confirms the file digest matches a signed attestation from this repo.
+
 ## Themes
 
 Themes are defined in the `themes/` folder as JSON files exporting the following:


### PR DESCRIPTION
> Artifact attestations enable you to create unfalsifiable provenance and integrity guarantees for the software you build. In turn, people who consume your software can verify where and how your software was built.

https://docs.github.com/en/actions/concepts/security/artifact-attestations