### PR TITLE
Remove em dash in install script

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -19,7 +19,7 @@ function Die($m)  { Write-Host "error: " -ForegroundColor Red -NoNewline; Write-
 
 function Assert-ReleaseAttestation([string]$Path) {
   if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
-    Write-Host "    (gh CLI not found; skipping provenance check — https://cli.github.com)" -ForegroundColor DarkGray
+    Write-Host "    (gh CLI not found; skipping provenance check - https://cli.github.com)" -ForegroundColor DarkGray
     return
   }
   Step "Verifying build provenance"


### PR DESCRIPTION
The em dash creates some funky encoding nonsense, and fails when cloning the repo and running it on Windows with `powershell -ExecutionPolicy Bypass -File install.ps1`. Changing it to a normal dash fixed it on my end. Here's a sample error it creates:

```
At C:\Users\User\dev\slick\install.ps1:21 char:60
+   if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
+                                                            ~
Missing closing '}' in statement block or type definition.
At C:\Users\User\dev\slick\install.ps1:20 char:51
+ function Assert-ReleaseAttestation([string]$Path) {
+                                                   ~
Missing closing '}' in statement block or type definition.
At C:\Users\User\dev\slick\install.ps1:22 char:92
+ ...  found; skipping provenance check â€” https://cli.github.com)" -Foreg ...
+                                                                 ~
Unexpected token ')' in expression or statement.
At C:\Users\User\dev\slick\install.ps1:25 char:9
+   Step "Verifying build provenance"
+         ~~~~~~~~~
Unexpected token 'Verifying' in expression or statement.
At C:\Users\User\dev\slick\install.ps1:247 char:58
+     Step "Downloading Electron $eVer (win32-$electronArch, ~140MB)"
+                                                          ~
Missing argument in parameter list.
At C:\Users\User\dev\slick\install.ps1:349 char:96
+ ... :// to official Slack:  powershell -File install.ps1 -RestoreHandler"
+                                                                         ~
The string is missing the terminator: ".
    + CategoryInfo          : ParserError: (:) [], ParentContainsErrorRecordException
    + FullyQualifiedErrorId : MissingEndCurlyBrace
```