### PR TITLE
Add external DB to PrivateChannelMapper as an option

### DIFF
--- a/plugins/PrivateChannelMapper/index.js
+++ b/plugins/PrivateChannelMapper/index.js
@@ -9,4 +9,14 @@ module.exports = {
   },
 
   renderer: fs.readFileSync(path.join(__dirname, 'renderer.js'), 'utf8'),
+  settings: {
+    flaron: {
+      type: "boolean",
+      name: "Use external private channel DB (Flaron)",
+      description: "If enabled, the plugin will show known private channel names if no local name is found.",
+      default: false,
+
+    }
+  },
+  restartRequired: true
 };

--- a/plugins/PrivateChannelMapper/index.js
+++ b/plugins/PrivateChannelMapper/index.js
@@ -15,7 +15,6 @@ module.exports = {
       label: 'Use external private channel DB (Flaron)',
       description: 'If enabled, the plugin will show known private channel names if no local name is found.',
       default: false,
-      restart,
     },
   },
 };

--- a/plugins/PrivateChannelMapper/index.js
+++ b/plugins/PrivateChannelMapper/index.js
@@ -15,6 +15,7 @@ module.exports = {
       label: 'Use external private channel DB (Flaron)',
       description: 'If enabled, the plugin will show known private channel names if no local name is found.',
       default: false,
+      restart
     },
   },
 };

--- a/plugins/PrivateChannelMapper/index.js
+++ b/plugins/PrivateChannelMapper/index.js
@@ -15,7 +15,7 @@ module.exports = {
       label: 'Use external private channel DB (Flaron)',
       description: 'If enabled, the plugin will show known private channel names if no local name is found.',
       default: false,
-      restart
+      restart,
     },
   },
 };

--- a/plugins/PrivateChannelMapper/index.js
+++ b/plugins/PrivateChannelMapper/index.js
@@ -12,7 +12,7 @@ module.exports = {
   settings: {
     flaron: {
       type: 'boolean',
-      name: 'Use external private channel DB (Flaron)',
+      label: 'Use external private channel DB (Flaron)',
       description: 'If enabled, the plugin will show known private channel names if no local name is found.',
       default: false,
     },

--- a/plugins/PrivateChannelMapper/index.js
+++ b/plugins/PrivateChannelMapper/index.js
@@ -11,11 +11,10 @@ module.exports = {
   renderer: fs.readFileSync(path.join(__dirname, 'renderer.js'), 'utf8'),
   settings: {
     flaron: {
-      type: "boolean",
-      name: "Use external private channel DB (Flaron)",
-      description: "If enabled, the plugin will show known private channel names if no local name is found.",
+      type: 'boolean',
+      name: 'Use external private channel DB (Flaron)',
+      description: 'If enabled, the plugin will show known private channel names if no local name is found.',
       default: false,
-
-    }
+    },
   },
 };

--- a/plugins/PrivateChannelMapper/index.js
+++ b/plugins/PrivateChannelMapper/index.js
@@ -18,5 +18,4 @@ module.exports = {
 
     }
   },
-  restartRequired: true
 };

--- a/plugins/PrivateChannelMapper/renderer.js
+++ b/plugins/PrivateChannelMapper/renderer.js
@@ -5,7 +5,6 @@
   if (window.__slickPCM) return;
   window.__slickPCM = true;
 
-  const KEY = 'slick:pcm:names';
   const SEL = '.c-missing_channel--private';
   const ID_RE = /^[CGD][A-Z0-9]{6,}$/;
 
@@ -79,7 +78,7 @@
     if (cachedFlaron && cachedFlaron[id]) return;
     if (pendingFlaron.has(id)) return;
     pendingFlaron.add(id);
-    const data = fetch('https://flaron.halceon.dev/channel/' + id)
+    fetch('https://flaron.halceon.dev/channel/' + id)
       .then((r) => r.json())
       .then((data) => {
         if (cachedFlaronUnavailable && cachedFlaronUnavailable.includes(id)) return;

--- a/plugins/PrivateChannelMapper/renderer.js
+++ b/plugins/PrivateChannelMapper/renderer.js
@@ -9,11 +9,18 @@
   const SEL = '.c-missing_channel--private';
   const ID_RE = /^[CGD][A-Z0-9]{6,}$/;
 
-  let names = read();
-  function read() {
+  let names = read("slick:pcm:names");
+
+  const isFlaronEnabled = window.__slickPluginSettings?.PrivateChannelMapper?.flaron;
+
+  let cachedFlaron = read("slick:pcm:flaron");
+  let cachedFlaronUnavailable = JSON.parse(localStorage.getItem("slick:pcm:flaronunknown") || "[]")
+  const pendingFlaron = new Set();
+
+  function read(key) {
     let raw;
     try {
-      raw = JSON.parse(localStorage.getItem(KEY)) || {};
+      raw = JSON.parse(localStorage.getItem(key)) || {};
     } catch {
       return {};
     }
@@ -21,10 +28,10 @@
     for (const k of Object.keys(raw)) if (ID_RE.test(k)) clean[k] = raw[k];
     return clean;
   }
-  function write() {
+  function write(key, val) {
     try {
-      localStorage.setItem(KEY, JSON.stringify(names));
-    } catch {}
+      localStorage.setItem(key, JSON.stringify(val));
+    } catch { }
   }
 
   function fiberOf(el) {
@@ -68,13 +75,47 @@
     return n;
   }
 
+  function getFlaron(id) {
+    if (cachedFlaron && cachedFlaron[id]) return;
+    if (pendingFlaron.has(id)) return;
+    pendingFlaron.add(id);
+    const data = fetch("https://flaron.halceon.dev/channel/" + id)
+      .then((r) => r.json())
+      .then((data) => {
+        if (cachedFlaronUnavailable && cachedFlaronUnavailable.includes(id)) return;
+        if (data && data.name) {
+          cachedFlaron = cachedFlaron || {};
+          cachedFlaron[id] = data.name;
+          write("slick:pcm:flaron", cachedFlaron);
+          applyAll();
+        } else {
+          if (data && data.error && data.error == "unknown") {
+            cachedFlaronUnavailable = cachedFlaronUnavailable || [];
+            cachedFlaronUnavailable.push(id);
+            write("slick:pcm:flaron-unknown", cachedFlaronUnavailable);
+            applyAll();
+          }
+        }
+        pendingFlaron.delete(id);
+      })
+      .catch(() => { });
+  }
+
   function apply(el) {
     const id = idOf(el);
     if (!id) return;
     const custom = names[id];
     el.title = custom ? id : '';
+
     const node = labelTextNode(el);
-    const want = custom || id;
+    let want;
+    if (isFlaronEnabled) {
+      getFlaron(id);
+      want = custom || cachedFlaron[id] || id;
+    } else {
+      want = custom || id;
+    }
+
     if (node.nodeValue !== want) node.nodeValue = want;
     el.classList.toggle('slick-pcm--named', !!custom);
   }
@@ -102,9 +143,9 @@
     input.setAttribute(
       'style',
       `position:fixed;left:${Math.round(r.left)}px;top:${Math.round(r.top)}px;` +
-        `min-width:${Math.max(120, Math.round(r.width) + 24)}px;z-index:2147483647;` +
-        `font:inherit;padding:2px 6px;border-radius:6px;border:1px solid #3a3a3a;` +
-        `background:#000;color:#fff;outline:none`,
+      `min-width:${Math.max(120, Math.round(r.width) + 24)}px;z-index:2147483647;` +
+      `font:inherit;padding:2px 6px;border-radius:6px;border:1px solid #3a3a3a;` +
+      `background:#000;color:#fff;outline:none`,
     );
     document.body.appendChild(input);
     input.focus();
@@ -114,7 +155,7 @@
         const v = input.value.trim();
         if (v) names[id] = v;
         else delete names[id];
-        write();
+        write("slick:pcm:names", names);
         closeEditor();
         applyAll();
       } else if (e.key === 'Escape') {

--- a/plugins/PrivateChannelMapper/renderer.js
+++ b/plugins/PrivateChannelMapper/renderer.js
@@ -10,10 +10,16 @@
 
   let names = read('slick:pcm:names');
 
-  const isFlaronEnabled = window.__slickPluginSettings?.PrivateChannelMapper?.flaron;
+  const FLARON_KEY = 'slick:pcm:flaron';
+  const FLARON_UNKNOWN_KEY = 'slick:pcm:flaron-unknown';
 
-  let cachedFlaron = read('slick:pcm:flaron');
-  let cachedFlaronUnavailable = JSON.parse(localStorage.getItem('slick:pcm:flaronunknown') || '[]');
+  function flaronEnabled() {
+    return !!window.__slickPluginSettings?.PrivateChannelMapper?.flaron;
+  }
+
+  const cachedFlaron = read(FLARON_KEY);
+  const flaronUnknown = read(FLARON_UNKNOWN_KEY);
+  const failedFlaron = new Set();
   const pendingFlaron = new Set();
 
   function read(key) {
@@ -74,49 +80,55 @@
     return n;
   }
 
+  function flaronUnknownRecently(id) {
+    const ts = flaronUnknown[id];
+    if (typeof ts !== 'number') return false;
+    if (Date.now() - ts < 24 * 60 * 60 * 1000) return true;
+    delete flaronUnknown[id];
+    return false;
+  }
+
   function getFlaron(id) {
-    if (cachedFlaron && cachedFlaron[id]) return;
-    if (pendingFlaron.has(id)) return;
+    if (cachedFlaron[id] || pendingFlaron.has(id) || failedFlaron.has(id)) return;
+    if (flaronUnknownRecently(id)) return;
     pendingFlaron.add(id);
     fetch('https://flaron.halceon.dev/channel/' + id)
       .then((r) => r.json())
       .then((data) => {
-        if (cachedFlaronUnavailable && cachedFlaronUnavailable.includes(id)) return;
-        if (data && data.name) {
-          cachedFlaron = cachedFlaron || {};
-          cachedFlaron[id] = data.name;
-          write('slick:pcm:flaron', cachedFlaron);
+        const name = data && typeof data.name === 'string' ? data.name.trim().slice(0, 100) : '';
+        if (name) {
+          cachedFlaron[id] = name;
+          write(FLARON_KEY, cachedFlaron);
           applyAll();
+        } else if (data && data.error === 'unknown') {
+          flaronUnknown[id] = Date.now();
+          write(FLARON_UNKNOWN_KEY, flaronUnknown);
         } else {
-          if (data && data.error && data.error == 'unknown') {
-            cachedFlaronUnavailable = cachedFlaronUnavailable || [];
-            cachedFlaronUnavailable.push(id);
-            write('slick:pcm:flaron-unknown', cachedFlaronUnavailable);
-            applyAll();
-          }
+          failedFlaron.add(id);
         }
-        pendingFlaron.delete(id);
       })
-      .catch(() => {});
+      .catch(() => {
+        failedFlaron.add(id);
+      })
+      .finally(() => pendingFlaron.delete(id));
   }
 
   function apply(el) {
     const id = idOf(el);
     if (!id) return;
     const custom = names[id];
-    el.title = custom ? id : '';
+    let flaron;
+    if (!custom && flaronEnabled()) {
+      getFlaron(id);
+      flaron = cachedFlaron[id];
+    }
+    const want = custom || flaron || id;
+    el.title = want === id ? '' : id;
 
     const node = labelTextNode(el);
-    let want;
-    if (isFlaronEnabled) {
-      getFlaron(id);
-      want = custom || cachedFlaron[id] || id;
-    } else {
-      want = custom || id;
-    }
-
     if (node.nodeValue !== want) node.nodeValue = want;
     el.classList.toggle('slick-pcm--named', !!custom);
+    el.classList.toggle('slick-pcm--flaron', !!flaron);
   }
 
   function applyAll() {
@@ -187,6 +199,7 @@
     }
     applyAll();
     obs.observe(document.body, { subtree: true, childList: true, characterData: true });
+    window.addEventListener('slick:plugin-settings', applyAll);
   }
   boot();
 })();

--- a/plugins/PrivateChannelMapper/renderer.js
+++ b/plugins/PrivateChannelMapper/renderer.js
@@ -9,12 +9,12 @@
   const SEL = '.c-missing_channel--private';
   const ID_RE = /^[CGD][A-Z0-9]{6,}$/;
 
-  let names = read("slick:pcm:names");
+  let names = read('slick:pcm:names');
 
   const isFlaronEnabled = window.__slickPluginSettings?.PrivateChannelMapper?.flaron;
 
-  let cachedFlaron = read("slick:pcm:flaron");
-  let cachedFlaronUnavailable = JSON.parse(localStorage.getItem("slick:pcm:flaronunknown") || "[]")
+  let cachedFlaron = read('slick:pcm:flaron');
+  let cachedFlaronUnavailable = JSON.parse(localStorage.getItem('slick:pcm:flaronunknown') || '[]');
   const pendingFlaron = new Set();
 
   function read(key) {
@@ -31,7 +31,7 @@
   function write(key, val) {
     try {
       localStorage.setItem(key, JSON.stringify(val));
-    } catch { }
+    } catch {}
   }
 
   function fiberOf(el) {
@@ -79,26 +79,26 @@
     if (cachedFlaron && cachedFlaron[id]) return;
     if (pendingFlaron.has(id)) return;
     pendingFlaron.add(id);
-    const data = fetch("https://flaron.halceon.dev/channel/" + id)
+    const data = fetch('https://flaron.halceon.dev/channel/' + id)
       .then((r) => r.json())
       .then((data) => {
         if (cachedFlaronUnavailable && cachedFlaronUnavailable.includes(id)) return;
         if (data && data.name) {
           cachedFlaron = cachedFlaron || {};
           cachedFlaron[id] = data.name;
-          write("slick:pcm:flaron", cachedFlaron);
+          write('slick:pcm:flaron', cachedFlaron);
           applyAll();
         } else {
-          if (data && data.error && data.error == "unknown") {
+          if (data && data.error && data.error == 'unknown') {
             cachedFlaronUnavailable = cachedFlaronUnavailable || [];
             cachedFlaronUnavailable.push(id);
-            write("slick:pcm:flaron-unknown", cachedFlaronUnavailable);
+            write('slick:pcm:flaron-unknown', cachedFlaronUnavailable);
             applyAll();
           }
         }
         pendingFlaron.delete(id);
       })
-      .catch(() => { });
+      .catch(() => {});
   }
 
   function apply(el) {
@@ -143,9 +143,9 @@
     input.setAttribute(
       'style',
       `position:fixed;left:${Math.round(r.left)}px;top:${Math.round(r.top)}px;` +
-      `min-width:${Math.max(120, Math.round(r.width) + 24)}px;z-index:2147483647;` +
-      `font:inherit;padding:2px 6px;border-radius:6px;border:1px solid #3a3a3a;` +
-      `background:#000;color:#fff;outline:none`,
+        `min-width:${Math.max(120, Math.round(r.width) + 24)}px;z-index:2147483647;` +
+        `font:inherit;padding:2px 6px;border-radius:6px;border:1px solid #3a3a3a;` +
+        `background:#000;color:#fff;outline:none`,
     );
     document.body.appendChild(input);
     input.focus();
@@ -155,7 +155,7 @@
         const v = input.value.trim();
         if (v) names[id] = v;
         else delete names[id];
-        write("slick:pcm:names", names);
+        write('slick:pcm:names', names);
         closeEditor();
         applyAll();
       } else if (e.key === 'Escape') {


### PR DESCRIPTION
Uses Flaron (https://flaron.halceon.dev) as the provider - there's a checkbox in settings to toggle it on/off, and it's off by default. Only tested on Windows but no reason for it not to work elsewhere. It caches external responses/failures and it shouldn't fire a million requests at the same time. It renders instead of the channel ID if no name is set. 

(this took me an embarassingly long amount of time to make)