### PR TITLE
fix(linux): pass no-sandbox in launch commands

### DIFF
--- a/install-linux.sh
+++ b/install-linux.sh
@@ -125,7 +125,7 @@ write_desktop_file() {
 Type=Application
 Name=Slick
 Comment=Slack client mod (BYOE)
-Exec=${target}/electron %U
+Exec=${target}/electron --no-sandbox %U
 Icon=slick
 Terminal=false
 Categories=Network;InstantMessaging;

--- a/scripts/byoe/build-handoff-linux.js
+++ b/scripts/byoe/build-handoff-linux.js
@@ -306,7 +306,7 @@ function writeDesktopFile(target) {
 Type=Application
 Name=Slick
 Comment=Slack client mod (BYOE)
-Exec=${path.join(target, 'electron')} %U
+Exec=${path.join(target, 'electron')} --no-sandbox %U
 Icon=slick
 Terminal=false
 Categories=Network;InstantMessaging;

--- a/scripts/launch-linux.sh
+++ b/scripts/launch-linux.sh
@@ -26,4 +26,4 @@ export SLICK_LAUNCH_T0
   exit 1
 }
 
-exec "$EBIN" "${DEBUG[@]}" "$@"
+exec "$EBIN" --no-sandbox "${DEBUG[@]}" "$@"


### PR DESCRIPTION
## Summary

- pass `--no-sandbox` from the installed Linux desktop entry
- pass it from the source-build desktop entry generator
- use the same flag in `launch-linux.sh`

## Why

The bundled `chrome-sandbox` is user-owned and mode 755, so launching Slick from the desktop entry aborts before the wrapper can apply its `app.commandLine.appendSwitch('no-sandbox')` call. Passing the switch directly to Electron avoids the fatal SUID sandbox check and matches the existing updater relaunch behavior.

## Validation

- `oxfmt --check`
- `oxlint`
- `shellcheck -S warning install-linux.sh scripts/launch-linux.sh`
- `node scripts/ci/validate.js`
- launched via the installed desktop entry without the sandbox fatal error