### PR TITLE
fix(byoe): coalesce repeated renderer hang notifications

### DIFF
--- a/scripts/byoe/build-handoff-app-win.js
+++ b/scripts/byoe/build-handoff-app-win.js
@@ -78,6 +78,7 @@ function copyRuntime(resources) {
     'scripts/byoe/switches.js',
     'scripts/byoe/updater.js',
     'scripts/byoe/watch.js',
+    'scripts/byoe/window-events.js',
     'scripts/theme.js',
   ]) {
     const target = path.join(runtime, file);

--- a/scripts/byoe/build-handoff-app.js
+++ b/scripts/byoe/build-handoff-app.js
@@ -93,6 +93,7 @@ function copyRuntime(resources) {
     'scripts/byoe/switches.js',
     'scripts/byoe/updater.js',
     'scripts/byoe/watch.js',
+    'scripts/byoe/window-events.js',
     'scripts/theme.js',
   ]) {
     const target = path.join(runtime, file);

--- a/scripts/byoe/build-handoff-linux.js
+++ b/scripts/byoe/build-handoff-linux.js
@@ -85,6 +85,7 @@ function copyRuntime(resources) {
     'scripts/byoe/switches.js',
     'scripts/byoe/updater.js',
     'scripts/byoe/watch.js',
+    'scripts/byoe/window-events.js',
     'scripts/theme.js',
   ]) {
     const target = path.join(runtime, file);

--- a/scripts/byoe/inject.js
+++ b/scripts/byoe/inject.js
@@ -54,6 +54,7 @@ const internals = require('./internals');
 const settings = require('./settings-ui');
 const { buildSpec } = require('../theme');
 const { createWatcher } = require('./watch');
+const { coalesceWindowHangEvents } = require('./window-events');
 perf.mark('modules loaded');
 
 const LAUNCHER_MS = process.env.SLICK_LAUNCH_T0
@@ -808,6 +809,7 @@ function initializeDocument(wc, value) {
   }
 }
 app.on('browser-window-created', (_event, win) => {
+  if (process.platform === 'linux') coalesceWindowHangEvents(win);
   if (firstWindow) {
     firstWindow = false;
     perf.mark('first window created');

--- a/scripts/byoe/window-events.js
+++ b/scripts/byoe/window-events.js
@@ -1,0 +1,23 @@
+'use strict';
+
+// Electron can report the same hang more than once before the renderer recovers.
+// Slack opens a native dialog for every BrowserWindow event, so overlapping
+// reports can leave multiple recovery dialogs on screen. Keep WebContents
+// events intact for diagnostics while exposing the window hang as one edge.
+function coalesceWindowHangEvents(win) {
+  const emit = win.emit;
+  let unresponsive = false;
+
+  win.emit = function coalescedWindowEmit(event, ...args) {
+    if (event === 'unresponsive') {
+      if (unresponsive) return false;
+      unresponsive = true;
+    } else if (event === 'responsive') {
+      unresponsive = false;
+    }
+
+    return emit.call(this, event, ...args);
+  };
+}
+
+module.exports = { coalesceWindowHangEvents };

--- a/scripts/byoe/window-events.js
+++ b/scripts/byoe/window-events.js
@@ -7,14 +7,20 @@
 function coalesceWindowHangEvents(win) {
   const emit = win.emit;
   let unresponsive = false;
+  const reset = () => {
+    unresponsive = false;
+  };
+
+  win.webContents?.on('render-process-gone', reset);
+  win.webContents?.on('did-start-navigation', (event) => {
+    if (event.isMainFrame && !event.isSameDocument) reset();
+  });
 
   win.emit = function coalescedWindowEmit(event, ...args) {
     if (event === 'unresponsive') {
       if (unresponsive) return false;
       unresponsive = true;
-    } else if (event === 'responsive') {
-      unresponsive = false;
-    }
+    } else if (event === 'responsive') reset();
 
     return emit.call(this, event, ...args);
   };

--- a/scripts/ci/performance.test.js
+++ b/scripts/ci/performance.test.js
@@ -12,6 +12,7 @@ const { redactString, rendererProbeSource, sanitize } = require('../byoe/diagnos
 const settings = require('../byoe/settings-ui');
 const { buildCatalog, hydrateCatalog, loadPlugins } = require('../byoe/plugins');
 const { createWatcher } = require('../byoe/watch');
+const { coalesceWindowHangEvents } = require('../byoe/window-events');
 
 const ROOT = path.resolve(__dirname, '..', '..');
 const PLUGINS_DIR = path.join(ROOT, 'plugins');
@@ -73,6 +74,20 @@ test('sanitize keeps the newest entries of an over-long rolling array', () => {
 
 test('renderer performance probe is valid JavaScript', () => {
   assert.doesNotThrow(() => new Function(rendererProbeSource(true)));
+});
+
+test('repeated window hang notifications are coalesced until responsive', () => {
+  const win = new (require('node:events').EventEmitter)();
+  const seen = [];
+  coalesceWindowHangEvents(win);
+  win.on('unresponsive', () => seen.push('unresponsive'));
+  win.on('responsive', () => seen.push('responsive'));
+
+  assert.equal(win.emit('unresponsive'), true);
+  assert.equal(win.emit('unresponsive'), false);
+  assert.equal(win.emit('responsive'), true);
+  assert.equal(win.emit('unresponsive'), true);
+  assert.deepEqual(seen, ['unresponsive', 'responsive', 'unresponsive']);
 });
 
 test('diagnostic control invokes the local export callback', async () => {

--- a/scripts/ci/performance.test.js
+++ b/scripts/ci/performance.test.js
@@ -77,7 +77,9 @@ test('renderer performance probe is valid JavaScript', () => {
 });
 
 test('repeated window hang notifications are coalesced until responsive', () => {
-  const win = new (require('node:events').EventEmitter)();
+  const EventEmitter = require('node:events');
+  const win = new EventEmitter();
+  win.webContents = new EventEmitter();
   const seen = [];
   coalesceWindowHangEvents(win);
   win.on('unresponsive', () => seen.push('unresponsive'));
@@ -88,6 +90,26 @@ test('repeated window hang notifications are coalesced until responsive', () => 
   assert.equal(win.emit('responsive'), true);
   assert.equal(win.emit('unresponsive'), true);
   assert.deepEqual(seen, ['unresponsive', 'responsive', 'unresponsive']);
+});
+
+test('window hang coalescing resets when the renderer terminates or navigates', () => {
+  const EventEmitter = require('node:events');
+  const win = new EventEmitter();
+  win.webContents = new EventEmitter();
+  const seen = [];
+  coalesceWindowHangEvents(win);
+  win.on('unresponsive', () => seen.push('unresponsive'));
+
+  win.emit('unresponsive');
+  win.webContents.emit('render-process-gone');
+  win.emit('unresponsive');
+  win.webContents.emit('did-start-navigation', { isMainFrame: false, isSameDocument: false });
+  assert.equal(win.emit('unresponsive'), false, 'subframe navigation must not reset the main renderer state');
+  win.webContents.emit('did-start-navigation', { isMainFrame: true, isSameDocument: true });
+  assert.equal(win.emit('unresponsive'), false, 'same-document navigation must not reset the renderer state');
+  win.webContents.emit('did-start-navigation', { isMainFrame: true, isSameDocument: false });
+  assert.equal(win.emit('unresponsive'), true);
+  assert.deepEqual(seen, ['unresponsive', 'unresponsive', 'unresponsive']);
 });
 
 test('diagnostic control invokes the local export callback', async () => {


### PR DESCRIPTION
## Summary
- coalesce duplicate Linux `BrowserWindow` unresponsive notifications within one hang episode
- preserve `webContents` hang events for diagnostics and reset after the renderer becomes responsive
- package the helper in every BYOE handoff and cover the state transition with a regression test

Slack opens one native recovery dialog for every window-level unresponsive event. Electron emitted that event twice before one responsive event in the reproduced incident, creating overlapping recovery dialogs. This keeps the real warning while preventing duplicates; it does not disable Electron's hang monitor.

## Validation
- `npm run fmt:check`
- `npm run lint`
- `npm run validate`
- `npm run test:perf`

The aggregate `npm run check` reached the shell lint step but this machine does not have `shellcheck` installed; no shell files changed.