### PR TITLE
fix: bChannel image sends leave the composer stuck

### DIFF
--- a/plugins/bChannel/renderer.js
+++ b/plugins/bChannel/renderer.js
@@ -479,6 +479,31 @@
     return result.blocks;
   }
 
+  function clearPendingFileUploads(store, pendingIds) {
+    if (!pendingIds.size || !store?.dispatch) return;
+    let runtimeRequire;
+    try {
+      runtimeRequire = getSlackRequire();
+    } catch (error) {
+      return;
+    }
+    for (const [id, factory] of Object.entries(runtimeRequire.m || {})) {
+      const source = String(factory);
+      if (!source.includes('pendingFileUploads')) continue;
+      const exports = runtimeRequire(id);
+      const candidate = Object.values(exports || {}).find(
+        (value) => typeof value === 'function' && /removePending|clearPending|deletePending/i.test(String(value)),
+      );
+      if (!candidate) continue;
+      for (const pendingId of pendingIds) {
+        try {
+          store.dispatch(candidate(pendingId));
+        } catch (error) {}
+      }
+      return;
+    }
+  }
+
   function composerAttachmentRoot(composer) {
     return (
       composer?.closest?.(
@@ -855,6 +880,10 @@
           includeBroadcastKeywordWarning: false,
         });
         await uploadStagedFiles(staged.token, uploads);
+        clearPendingFileUploads(
+          meta.store,
+          new Set(Array.isArray(args?.pendingFileIds) ? args.pendingFileIds.map(String) : []),
+        );
         return result;
       } catch (error) {
         await discardIntent(staged.token);


### PR DESCRIPTION
sending a message with an image through bChannel wiped the pending file ids from the send call, so Slack's upload-complete flow never ran. the pending upload stayed in redux forever, and after switching channels or reloading the composer would break on the stale draft and you couldn't send anything.

now, once the handoff + file upload succeed, we tell Slack to drop the pending uploads. same trick as the serializer lookup, wrapped in try/catch so a Slack rename just makes it a no-op instead of breaking sends.