### PR TITLE
harden: sanitize child_process call in build-handoff-app.js...

### DIFF
--- a/scripts/byoe/build-handoff-app.js
+++ b/scripts/byoe/build-handoff-app.js
@@ -406,7 +406,7 @@ if (!problem) {
   const codesignArgs = ['--force', '--deep', '--sign', '-'];
   if (fs.existsSync(ENTITLEMENTS)) codesignArgs.push('--entitlements', ENTITLEMENTS);
   codesignArgs.push(target);
-  run('/usr/bin/codesign', codesignArgs);
+  run('codesign', codesignArgs);
 
   console.log(JSON.stringify({ app: target, profile, note: 'Open this to register slack:// to Slick' }, null, 2));
 }

--- a/scripts/byoe/build-handoff-app.js
+++ b/scripts/byoe/build-handoff-app.js
@@ -52,11 +52,14 @@ function parseArgs(argv) {
   return o;
 }
 
-function run(cmd, args) {
+const ALLOWED_CMDS = { plutil: '/usr/bin/plutil', codesign: '/usr/bin/codesign' };
+function run(name, args) {
+  const cmd = ALLOWED_CMDS[name];
+  if (!cmd) throw new Error(`Unknown command: ${name}`);
   const r = spawnSync(cmd, args, { encoding: 'utf8' });
-  if (r.status !== 0) throw new Error((r.stderr || r.stdout || `${cmd} failed`).trim());
+  if (r.status !== 0) throw new Error((r.stderr || r.stdout || `${name} failed`).trim());
 }
-const plutil = (...args) => run('/usr/bin/plutil', args);
+const plutil = (...args) => run('plutil', args);
 
 function packAsar(files, outPath) {
   let offset = 0;


### PR DESCRIPTION
## Summary
Harden input handling in `scripts/byoe/build-handoff-app.js` (flagged by semgrep).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | javascript.lang.security.detect-child-process.detect-child-process |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `javascript.lang.security.detect-child-process.detect-child-process` |
| **File** | `scripts/byoe/build-handoff-app.js:56` |
| **Assessment** | Defensive hardening |

**Description**: Detected calls to child_process from a function argument `cmd`. This could lead to a command injection if the input is user controllable. Try to avoid calls to child_process, and if it is needed ensure user input is correctly sanitized or sandboxed. 

## Threat Model Context

This is a private Node.js application (not published to npm). Vulnerabilities affect this application's own runtime only.

## Changes
- `scripts/byoe/build-handoff-app.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
